### PR TITLE
Maven's artifactId should be in the lower-case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.dzikoysk</groupId>
-    <artifactId>Panda</artifactId>
+    <artifactId>panda</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
> **artifactId** is the name of the jar without version. If you created it then you can choose whatever name you want with lowercase letters and no strange symbols. If it's a third party jar you have to take the name of the jar as it's distributed.
eg. `maven`, `commons-math`

https://maven.apache.org/guides/mini/guide-naming-conventions.html